### PR TITLE
Use HaystackFinderEngine everywhere to avoid problems when reading

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 1.0.3 / 2018-09-05 User HaystackFinderEngine everywhere
+Solves problems with using custom finders that are specified in default_finders.xml
+
 ## 1.0.2 / 2018-09-05 Make CldrRegion public
 Needs to be public so that it can be used by Spring configuration files in other packages
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-secrets-commons</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>

--- a/src/main/java/com/expedia/www/haystack/commons/secretDetector/DetectorBase.java
+++ b/src/main/java/com/expedia/www/haystack/commons/secretDetector/DetectorBase.java
@@ -16,19 +16,17 @@
  */
 package com.expedia.www.haystack.commons.secretDetector;
 
-import io.dataapps.chlorine.finder.FinderEngine;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 @SuppressWarnings("AbstractClassWithoutAbstractMethods")
 public abstract class DetectorBase {
-    protected final FinderEngine finderEngine;
+    protected final HaystackFinderEngine haystackFinderEngine;
     protected final S3ConfigFetcherBase s3ConfigFetcher;
 
-    protected DetectorBase(FinderEngine finderEngine, S3ConfigFetcherBase s3ConfigFetcher) {
-        this.finderEngine = finderEngine;
+    protected DetectorBase(HaystackFinderEngine haystackFinderEngine, S3ConfigFetcherBase s3ConfigFetcher) {
+        this.haystackFinderEngine = haystackFinderEngine;
         this.s3ConfigFetcher = s3ConfigFetcher;
     }
 

--- a/src/main/java/com/expedia/www/haystack/commons/secretDetector/json/JsonDetector.java
+++ b/src/main/java/com/expedia/www/haystack/commons/secretDetector/json/JsonDetector.java
@@ -17,13 +17,13 @@
 package com.expedia.www.haystack.commons.secretDetector.json;
 
 import com.expedia.www.haystack.commons.secretDetector.DetectorBase;
+import com.expedia.www.haystack.commons.secretDetector.HaystackFinderEngine;
 import com.expedia.www.haystack.commons.secretDetector.S3ConfigFetcher;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.netflix.servo.util.VisibleForTesting;
-import io.dataapps.chlorine.finder.FinderEngine;
 
 import java.util.Deque;
 import java.util.HashMap;
@@ -35,11 +35,11 @@ import java.util.Map;
 @SuppressWarnings("WeakerAccess")
 public class JsonDetector extends DetectorBase {
     public JsonDetector(String bucket) {
-        this(new FinderEngine(), new S3ConfigFetcher(bucket, "secret-detector/jsonWhiteListItems.txt"));
+        this(new HaystackFinderEngine(), new S3ConfigFetcher(bucket, "secret-detector/jsonWhiteListItems.txt"));
     }
 
-    public JsonDetector(FinderEngine finderEngine, S3ConfigFetcher s3ConfigFetcher) {
-        super(finderEngine, s3ConfigFetcher);
+    public JsonDetector(HaystackFinderEngine haystackFinderEngine, S3ConfigFetcher s3ConfigFetcher) {
+        super(haystackFinderEngine, s3ConfigFetcher);
     }
 
     /**
@@ -94,7 +94,7 @@ public class JsonDetector extends DetectorBase {
                                      Deque<Object> ids,
                                      JsonPrimitive value) {
         if (value.isString()) {
-            final Map<String, List<String>> secrets = finderEngine.findWithType(value.getAsString());
+            final Map<String, List<String>> secrets = haystackFinderEngine.findWithType(value.getAsString());
             if (!secrets.isEmpty()) {
                 putKeysOfSecretsIntoMap(mapOfTypeToKeysOfSecrets, getCompleteHierarchy(ids), secrets);
             }
@@ -103,7 +103,7 @@ public class JsonDetector extends DetectorBase {
                // turn on number detection and whitelist the false positives that result. We will do this for both JSON
                // and XML BLOBs, and perhaps for fastinfoset BLOBs too.
         } else if (value.isNumber()) {
-            final Map<String, List<String>> secrets = finderEngine.findWithType(value.getAsNumber().toString());
+            final Map<String, List<String>> secrets = haystackFinderEngine.findWithType(value.getAsNumber().toString());
             if (!secrets.isEmpty()) {
                 putKeysOfSecretsIntoMap(mapOfTypeToKeysOfSecrets, getCompleteHierarchy(ids), secrets);
             }

--- a/src/main/java/com/expedia/www/haystack/commons/secretDetector/span/SpanDetector.java
+++ b/src/main/java/com/expedia/www/haystack/commons/secretDetector/span/SpanDetector.java
@@ -21,11 +21,11 @@ import com.expedia.open.tracing.Span;
 import com.expedia.open.tracing.Tag;
 import com.expedia.www.haystack.commons.secretDetector.DetectorBase;
 import com.expedia.www.haystack.commons.secretDetector.FinderNameAndServiceName;
+import com.expedia.www.haystack.commons.secretDetector.HaystackFinderEngine;
 import com.expedia.www.haystack.metrics.MetricObjects;
 import com.google.common.base.Strings;
 import com.netflix.servo.monitor.Counter;
 import com.netflix.servo.util.VisibleForTesting;
-import io.dataapps.chlorine.finder.FinderEngine;
 import org.apache.kafka.streams.kstream.ValueMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,17 +61,17 @@ public class SpanDetector extends DetectorBase implements ValueMapper<Span, Iter
 
     public SpanDetector(String bucket, String application) {
         this(LoggerFactory.getLogger(SpanDetector.class),
-                new FinderEngine(),
+                new HaystackFinderEngine(),
                 new Factory(),
                 new SpanS3ConfigFetcher(bucket, "secret-detector/whiteList.txt"), application);
     }
 
     public SpanDetector(Logger detectorLogger,
-                        FinderEngine finderEngine,
+                        HaystackFinderEngine haystackFinderEngine,
                         Factory detectorFactory,
                         SpanS3ConfigFetcher spanS3ConfigFetcher,
                         String application) {
-        super(finderEngine, spanS3ConfigFetcher);
+        super(haystackFinderEngine, spanS3ConfigFetcher);
         this.logger = detectorLogger;
         this.factory = detectorFactory;
         this.application = application;
@@ -98,11 +98,11 @@ public class SpanDetector extends DetectorBase implements ValueMapper<Span, Iter
         for (final Tag tag : tags) {
             if (!Strings.isNullOrEmpty(tag.getVStr())) {
                 final String input = tag.getVStr();
-                putKeysOfSecretsIntoMap(mapOfTypeToKeysOfSecrets, tag.getKey(), finderEngine.findWithType(input));
+                putKeysOfSecretsIntoMap(mapOfTypeToKeysOfSecrets, tag.getKey(), haystackFinderEngine.findWithType(input));
             } else if (!tag.getVBytes().isEmpty()) {
                 @SuppressWarnings("ObjectAllocationInLoop")
                 final String input = new String(tag.getVBytes().toByteArray());
-                putKeysOfSecretsIntoMap(mapOfTypeToKeysOfSecrets, tag.getKey(), finderEngine.findWithType(input));
+                putKeysOfSecretsIntoMap(mapOfTypeToKeysOfSecrets, tag.getKey(), haystackFinderEngine.findWithType(input));
             }
         }
     }

--- a/src/main/java/com/expedia/www/haystack/commons/secretDetector/span/SpanSecretMasker.java
+++ b/src/main/java/com/expedia/www/haystack/commons/secretDetector/span/SpanSecretMasker.java
@@ -21,12 +21,12 @@ import com.expedia.open.tracing.Span;
 import com.expedia.open.tracing.Tag;
 import com.expedia.www.haystack.commons.secretDetector.DetectorBase;
 import com.expedia.www.haystack.commons.secretDetector.FinderNameAndServiceName;
+import com.expedia.www.haystack.commons.secretDetector.HaystackFinderEngine;
 import com.expedia.www.haystack.metrics.MetricObjects;
 import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
 import com.netflix.servo.monitor.Counter;
 import com.netflix.servo.util.VisibleForTesting;
-import io.dataapps.chlorine.finder.FinderEngine;
 import org.apache.kafka.streams.kstream.ValueMapper;
 import org.slf4j.LoggerFactory;
 
@@ -62,19 +62,19 @@ public class SpanSecretMasker extends DetectorBase implements ValueMapper<Span, 
 
     public SpanSecretMasker(String bucket, String application) {
         //noinspection LoggerInitializedWithForeignClass
-        this(new FinderEngine(),
+        this(new HaystackFinderEngine(),
                 new Factory(),
                 new SpanS3ConfigFetcher(bucket, "secret-detector/whiteListItems.txt"),
                 new SpanNameAndCountRecorder(LoggerFactory.getLogger(SpanNameAndCountRecorder.class), Clock.systemUTC()),
                 application);
     }
 
-    public SpanSecretMasker(FinderEngine finderEngine,
+    public SpanSecretMasker(HaystackFinderEngine haystackFinderEngine,
                             SpanSecretMasker.Factory spanSecretMaskerFactory,
                             SpanS3ConfigFetcher spanS3ConfigFetcher,
                             SpanNameAndCountRecorder spanNameAndCountRecorder,
                             String application) {
-        super(finderEngine, spanS3ConfigFetcher);
+        super(haystackFinderEngine, spanS3ConfigFetcher);
         this.factory = spanSecretMaskerFactory;
         this.spanNameAndCountRecorder = spanNameAndCountRecorder;
         this.application = application;
@@ -197,7 +197,7 @@ public class SpanSecretMasker extends DetectorBase implements ValueMapper<Span, 
     }
 
     private Map<String, List<String>> findSecrets(Tag tag, String input) {
-        final Map<String, List<String>> mapOfTypeToValuesOfSecrets = finderEngine.findWithType(input);
+        final Map<String, List<String>> mapOfTypeToValuesOfSecrets = haystackFinderEngine.findWithType(input);
         for (Map.Entry<String, List<String>> stringListEntry : mapOfTypeToValuesOfSecrets.entrySet()) {
             stringListEntry.getValue().replaceAll(s -> tag.getKey());
         }

--- a/src/main/java/com/expedia/www/haystack/commons/secretDetector/xml/XmlDetector.java
+++ b/src/main/java/com/expedia/www/haystack/commons/secretDetector/xml/XmlDetector.java
@@ -17,8 +17,8 @@
 package com.expedia.www.haystack.commons.secretDetector.xml;
 
 import com.expedia.www.haystack.commons.secretDetector.DetectorBase;
+import com.expedia.www.haystack.commons.secretDetector.HaystackFinderEngine;
 import com.expedia.www.haystack.commons.secretDetector.S3ConfigFetcher;
-import io.dataapps.chlorine.finder.FinderEngine;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
@@ -38,11 +38,11 @@ public class XmlDetector extends DetectorBase {
     private static final String[] ZERO_LENGTH_STRING_ARRAY = new String[0];
 
     public XmlDetector(String bucket) {
-        this(new FinderEngine(), new S3ConfigFetcher(bucket, "secret-detector/xmlWhiteListItems.txt"));
+        this(new HaystackFinderEngine(), new S3ConfigFetcher(bucket, "secret-detector/xmlWhiteListItems.txt"));
     }
 
-    public XmlDetector(FinderEngine finderEngine, S3ConfigFetcher s3ConfigFetcher) {
-        super(finderEngine, s3ConfigFetcher);
+    public XmlDetector(HaystackFinderEngine haystackFinderEngine, S3ConfigFetcher s3ConfigFetcher) {
+        super(haystackFinderEngine, s3ConfigFetcher);
     }
 
     /**
@@ -67,7 +67,7 @@ public class XmlDetector extends DetectorBase {
     private void findSecretsInNodeValue(Node node, Map<String, List<String>> mapOfTypeToKeysOfSecrets) {
         final String nodeValue = node.getNodeValue();
         if (nodeValue != null) {
-            final Map<String, List<String>> secrets = finderEngine.findWithType(nodeValue);
+            final Map<String, List<String>> secrets = haystackFinderEngine.findWithType(nodeValue);
             if (!secrets.isEmpty()) {
                 final String completeHierarchy = getCompleteHierarchy(node);
                 if (completeHierarchy.endsWith("/#text")) { // prevents double detection of attribute values;

--- a/src/test/java/com/expedia/www/haystack/commons/secretDetector/json/JsonDetectorTest.java
+++ b/src/test/java/com/expedia/www/haystack/commons/secretDetector/json/JsonDetectorTest.java
@@ -22,7 +22,6 @@ import com.google.gson.Gson;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import io.dataapps.chlorine.finder.FinderEngine;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,7 +45,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 @RunWith(MockitoJUnitRunner.class)
 public class JsonDetectorTest {
     private static final String BUCKET = RANDOM.nextLong() + "BUCKET";
-    private static final FinderEngine FINDER_ENGINE = new HaystackFinderEngine();
+    private static final HaystackFinderEngine HAYSTACK_FINDER_ENGINE = new HaystackFinderEngine();
     private static final String JSON_TEMPLATE =
             "{\"rootElement\": {\"childMap\": {\"childKey\":%s}, \"childArray\": [%s]}}";
     private static final String NOT_A_SECRET_STRING = "\"NotASecret\"";
@@ -60,7 +59,7 @@ public class JsonDetectorTest {
 
     @Before
     public void setUp() {
-        jsonDetector = new JsonDetector(FINDER_ENGINE, mockS3ConfigFetcher);
+        jsonDetector = new JsonDetector(HAYSTACK_FINDER_ENGINE, mockS3ConfigFetcher);
     }
 
     @After

--- a/src/test/java/com/expedia/www/haystack/commons/secretDetector/span/SpanDetectorTest.java
+++ b/src/test/java/com/expedia/www/haystack/commons/secretDetector/span/SpanDetectorTest.java
@@ -23,7 +23,6 @@ import com.expedia.www.haystack.commons.secretDetector.TestConstantsAndCommonCod
 import com.expedia.www.haystack.commons.secretDetector.span.SpanDetector.Factory;
 import com.expedia.www.haystack.metrics.MetricObjects;
 import com.netflix.servo.monitor.Counter;
-import io.dataapps.chlorine.finder.FinderEngine;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -72,7 +71,7 @@ public class SpanDetectorTest {
     private static final String BUCKET = RANDOM.nextLong() + "BUCKET";
     private static final String FINDER_NAME = RANDOM.nextLong() + "FINDER_NAME";
     private static final String SERVICE_NAME = RANDOM.nextLong() + "SERVICE_NAME";
-    private static final FinderEngine FINDER_ENGINE = new HaystackFinderEngine();
+    private static final HaystackFinderEngine HAYSTACK_FINDER_ENGINE = new HaystackFinderEngine();
     private static final String CREDIT_CARD_FINDER_NAME = "Credit_Card";
     private static final String CREDIT_CARD_FINDER_NAME_IN_FINDERS_DEFAULT_DOT_XML = CREDIT_CARD_FINDER_NAME;
     private static final String EMAIL_FINDER_NAME_IN_FINDERS_DEFAULT_DOT_XML = "Email";
@@ -101,7 +100,7 @@ public class SpanDetectorTest {
 
     @Before
     public void setUp() {
-        spanDetector = new SpanDetector(mockLogger, FINDER_ENGINE, mockFactory, mockSpanS3ConfigFetcher, APPLICATION);
+        spanDetector = new SpanDetector(mockLogger, HAYSTACK_FINDER_ENGINE, mockFactory, mockSpanS3ConfigFetcher, APPLICATION);
         factory = new Factory(mockMetricObjects);
     }
 

--- a/src/test/java/com/expedia/www/haystack/commons/secretDetector/span/SpanSecretMaskerTest.java
+++ b/src/test/java/com/expedia/www/haystack/commons/secretDetector/span/SpanSecretMaskerTest.java
@@ -24,7 +24,6 @@ import com.expedia.www.haystack.commons.secretDetector.HaystackFinderEngine;
 import com.expedia.www.haystack.commons.secretDetector.span.SpanSecretMasker.Factory;
 import com.expedia.www.haystack.metrics.MetricObjects;
 import com.netflix.servo.monitor.Counter;
-import io.dataapps.chlorine.finder.FinderEngine;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,7 +68,7 @@ import static org.mockito.Mockito.when;
 public class SpanSecretMaskerTest {
     private static final String APPLICATION = RANDOM.nextLong() + "APPLICATION";
     private static final String BUCKET = RANDOM.nextLong() + "BUCKET";
-    private static final FinderEngine FINDER_ENGINE = new HaystackFinderEngine();
+    private static final HaystackFinderEngine HAYSTACK_FINDER_ENGINE = new HaystackFinderEngine();
     private static final String EMAIL_FINDER_NAME_IN_FINDERS_DEFAULT_DOT_XML = "Email";
     private static final FinderNameAndServiceName EMAIL_FINDER_NAME_AND_SERVICE_NAME =
             new FinderNameAndServiceName(EMAIL_FINDER_NAME_IN_FINDERS_DEFAULT_DOT_XML, SERVICE_NAME);
@@ -101,7 +100,7 @@ public class SpanSecretMaskerTest {
     @Before
     public void setUp() {
         spanSecretMasker = new SpanSecretMasker(
-                FINDER_ENGINE, mockFactory, mockSpanS3ConfigFetcher, mockSpanNameAndCountRecorder, APPLICATION);
+                HAYSTACK_FINDER_ENGINE, mockFactory, mockSpanS3ConfigFetcher, mockSpanNameAndCountRecorder, APPLICATION);
         factory = new Factory(mockMetricObjects);
     }
 

--- a/src/test/java/com/expedia/www/haystack/commons/secretDetector/xml/XmlDetectorTest.java
+++ b/src/test/java/com/expedia/www/haystack/commons/secretDetector/xml/XmlDetectorTest.java
@@ -20,7 +20,6 @@ import com.expedia.www.haystack.commons.secretDetector.HaystackFinderEngine;
 import com.expedia.www.haystack.commons.secretDetector.S3ConfigFetcher;
 import com.expedia.www.haystack.metrics.MetricObjects;
 import com.netflix.servo.monitor.Counter;
-import io.dataapps.chlorine.finder.FinderEngine;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,7 +45,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 @RunWith(MockitoJUnitRunner.class)
 public class XmlDetectorTest {
     private static final String BUCKET = RANDOM.nextLong() + "BUCKET";
-    private static final FinderEngine FINDER_ENGINE = new HaystackFinderEngine();
+    private static final HaystackFinderEngine HAYSTACK_FINDER_ENGINE = new HaystackFinderEngine();
     private static final String XML_TEMPLATE =
             "<rootElement rootAttribute='%s'>%s<childElement childAttribute='%s'>%s</childElement></rootElement>";
     private static final String NOT_A_SECRET = "NotASecret";
@@ -82,7 +81,7 @@ public class XmlDetectorTest {
 
     @Before
     public void setUp() {
-        xmlDetector = new XmlDetector(FINDER_ENGINE, mockS3ConfigFetcher);
+        xmlDetector = new XmlDetector(HAYSTACK_FINDER_ENGINE, mockS3ConfigFetcher);
     }
 
     @After


### PR DESCRIPTION
finders_default.xml files that contain custom finders that don't have
a default constructor.