### PR TITLE
Make HaystackFinderEngine non-final, so that other packages using it

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 1.0.4 / 2018-09-06 Make HaystackFinderEngine non-final
+So Mockito can mock it in packages that use it (e.g. haystack-pipes)
+
 ## 1.0.3 / 2018-09-05 User HaystackFinderEngine everywhere
 Solves problems with using custom finders that are specified in default_finders.xml
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-secrets-commons</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>

--- a/src/main/java/com/expedia/www/haystack/commons/secretDetector/HaystackFinderEngine.java
+++ b/src/main/java/com/expedia/www/haystack/commons/secretDetector/HaystackFinderEngine.java
@@ -18,7 +18,7 @@ package com.expedia.www.haystack.commons.secretDetector;
 
 import io.dataapps.chlorine.finder.FinderEngine;
 
-public final class HaystackFinderEngine extends FinderEngine {
+public class HaystackFinderEngine extends FinderEngine {
     public HaystackFinderEngine() {
         super((new HaystackFinderProvider()).getFinders(), false);
     }


### PR DESCRIPTION
can mock it in their unit tests.